### PR TITLE
feat: use ipfs.io as default gatway

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ $ ipfs-get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy
 ✅ Wrote ./bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy
 ```
 
-A thin wrapper over [@ipld/car](https://github.com/ipld/js-car) and [unix-fs-exporter](https://github.com/ipfs/js-ipfs-unixfs/tree/master/packages/ipfs-unixfs-exporter). It fetches the data by from the IPFS gateway api as a .car file, extacts the cids and blocks, verifying them as it goes, and writes the reassembled data to disk.
+A thin wrapper over [@ipld/car](https://github.com/ipld/js-car) and [unix-fs-exporter](https://github.com/ipfs/js-ipfs-unixfs/tree/master/packages/ipfs-unixfs-exporter). It fetches the content by CID over HTTP from the IPFS gateway as a Content-addressed Archive (CAR), extacts the cids and blocks, verifying them as it goes, and writes the files to disk.
 
-⚠️ **This tool will become useful once [go-ipfs v0.9.0 lands](https://github.com/ipfs/go-ipfs/issues/8058)**, and is deployed to the ipfs.io and dweb.link gateway. Until then it can only fetch car files from your local IPFS API, or a remote one that you have authenticated access to. In go-ipfs v0.9.0, the `/api/v0/dag/export` endpoint will become part of the public gateway api, at which point you can use this tool to fetch and locally verify content by cid from a gateway over http, which is new ✨ 
+In [go-ipfs v0.9.0](https://github.com/ipfs/go-ipfs/issues/8058), the `/api/v0/dag/export` endpoint is available to the public gateway api, allowing us to fetch content as CAR file.
 
-Before now folks just did an http get, and optimistically tried to re-add the response to a local ipfs node, which is error prone; if any non-default flags were used when adding the content, then the CID you get when adding locally would not match unless you knew ahead of time to use the same flags. By using car files, the CIDs for the blocks travel with the data, so `ipfs-get` is able to verify them, regardless of how the DAG was created (_well, it only supports sha256 verification currently, for dag-pb and dag-cbor, but that covers the vast majority of existing DAGs._)
+Before that API was available folks just did an http get to /ipfs/<CID>, and either trusted the gateway, or optimistically tried to re-add the response to a local ipfs node to check it hashed to the same CID, which is error prone; if any non-default flags were used when adding the content, then the CID you get when adding locally would not match unless you knew ahead of time to use the same flags. By using car files, the CIDs for the blocks travel with the data, so `ipfs-get` is able to verify them, regardless of how the DAG was created (_well, it only supports sha256 verification currently, for dag-pb and dag-cbor, but that covers the vast majority of existing DAGs created via IPFS._)
 
 ## Usage
 
@@ -23,12 +23,11 @@ Install `ipfs-get` globally with `npm i -g ipfs-get` or run it via npx `npx ipfs
 # fetch and verify a file by cid from you local gateway
 ipfs-get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy
 
-# fetch and verify a file by cid from ipfs.io (wait till go-ipfs v0.9.0 is released)
-ipfs-get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy --gateway https://ipfs.io
+# try it out with a local gateway (using go-ipfs v0.9.0)
+ipfs-get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy --gateway http://127.0.0.1:5001
 
-# fetch and verify a file by cid and pick the output filename
+# pick the output filename
 ipfs-get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy --output room-guardian.jpg
-
 ```
 
 ## How
@@ -38,4 +37,3 @@ ipfs-get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy --output ro
 - Start at the root as defined by the car file header
 - Verify each block by hashing the block as you pull it from the car, and compare the hash with the CID. Fail if not matched.
 - Assemble the blocks into the files and write it to disk.
-

--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ const options = {
     gateway: {
       type: 'string',
       alias: 'g',
-      default: 'http://127.0.0.1:5001'
+      default: 'https://ipfs.io'
     },
     output: {
       type: 'string',
@@ -18,12 +18,21 @@ const options = {
 }
 
 const cli = meow(`
-  Usage
-  $ ipfs-get <cid>
+Usage
+  $ ipfs-get <cid> [--gateway https://ipfs.io] [--output <path>]
+Example
+  $ ipfs-get bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy --output guardian.jpg
+Options
+  --gateway <URL> the ipfs gateway to fetch the cid from as a CAR.
+  --output <path> where to write the output to
 `, options)
+
+if (!cli.input[0]) {
+  cli.showHelp()
+}
 
 ipfsGet({
   cid: cli.input[0],
-  gateway: new URL(cli.flags.gateway),
+  gateway: cli.flags.gateway,
   output: cli.flags.output
 })

--- a/index.js
+++ b/index.js
@@ -14,8 +14,9 @@ const hashes = {
 }
 
 export async function ipfsGet ({ cid, gateway, output }) {
-  console.log(`📡 Fetching .car file from ${gateway}`)
-  const carStream = await fetchCar(cid, gateway)
+  const gatewayUrl = toUrl(gateway)
+  console.log(`📡 Fetching .car file from ${gatewayUrl}`)
+  const carStream = await fetchCar(cid, gatewayUrl)
   const carReader = await CarReader.fromIterable(carStream)
   const { blockCount, filename } = await extractCar({ cid, carReader, output })
   console.log(`🔐 Verified ${blockCount}/${blockCount} block${blockCount === 1 ? '' : 's'}`)
@@ -75,4 +76,12 @@ async function isValid ({ cid, bytes }) {
   }
   const hash = await hashfn.digest(bytes)
   return toHex(hash.digest) === toHex(cid.multihash.digest)
+}
+
+function toUrl (str) {
+  if (!str.match('://')) {
+    const scheme = ['localhost', '127.0.0.1'].includes(str) ? 'http' : 'https'
+    return toUrl(`${scheme}://${str}`)
+  }
+  return new URL(str)
 }


### PR DESCRIPTION
- ipfs.io now has /api/v0/dag/export powers!

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>