### PR TITLE
Fix bug and use the public gateway car response

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ipld/car": "^1.0.1",
+        "@ipld/car": "^5.0.1",
         "ipfs-unixfs-exporter": "9.0.2",
         "isomorphic-unfetch": "^3.1.0",
         "it-pipe": "^1.1.0",
@@ -150,34 +150,50 @@
       }
     },
     "node_modules/@ipld/car": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-1.0.6.tgz",
-      "integrity": "sha512-YWiQ0SrtzDw/d11GnW1X1MOhjA+HdDshMo7HC9nCKplxBWsdEx6cWZFP6UNrdCCHMdGQIHVo270bROgKTb1kHg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.0.1.tgz",
+      "integrity": "sha512-YPXr1TztVmTPE4MerjKpFMuIll73MqvEakzWDMqj4uGJnwkY+tE0SlBGmqkMSofOgVMQAxZ6JtuRA93WlTzb8w==",
       "dependencies": {
-        "@ipld/dag-cbor": "^5.0.0",
-        "@types/varint": "^6.0.0",
-        "multiformats": "^8.0.3",
+        "@ipld/dag-cbor": "^8.0.0",
+        "cborg": "^1.9.0",
+        "multiformats": "^10.0.2",
         "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/car/node_modules/multiformats": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+      "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@ipld/dag-cbor": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.5.tgz",
-      "integrity": "sha512-nSWGvqhwE9nHsrBx8YL4TiwhsitLhJ54Md5BMCUdK+s10QPxYsO7l/rRxU9bLV/L13WUTfLEll2K3Q2ijlZCWw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
+      "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
       "dependencies": {
-        "cborg": "^1.2.1",
-        "multiformats": "^8.0.3"
+        "cborg": "^1.6.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@ipld/dag-pb": {
       "version": "3.0.2",
@@ -357,14 +373,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
-    },
-    "node_modules/@types/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/acorn": {
       "version": "8.2.4",
@@ -2963,28 +2971,6 @@
         "p-queue": "^7.3.0",
         "uint8arrays": "^4.0.2"
       },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-unixfs-exporter/node_modules/@ipld/dag-cbor": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
-      "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
-      "dependencies": {
-        "cborg": "^1.6.0",
-        "multiformats": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-unixfs-exporter/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -6404,36 +6390,36 @@
       }
     },
     "@ipld/car": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-1.0.6.tgz",
-      "integrity": "sha512-YWiQ0SrtzDw/d11GnW1X1MOhjA+HdDshMo7HC9nCKplxBWsdEx6cWZFP6UNrdCCHMdGQIHVo270bROgKTb1kHg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.0.1.tgz",
+      "integrity": "sha512-YPXr1TztVmTPE4MerjKpFMuIll73MqvEakzWDMqj4uGJnwkY+tE0SlBGmqkMSofOgVMQAxZ6JtuRA93WlTzb8w==",
       "requires": {
-        "@ipld/dag-cbor": "^5.0.0",
-        "@types/varint": "^6.0.0",
-        "multiformats": "^8.0.3",
+        "@ipld/dag-cbor": "^8.0.0",
+        "cborg": "^1.9.0",
+        "multiformats": "^10.0.2",
         "varint": "^6.0.0"
       },
       "dependencies": {
         "multiformats": {
-          "version": "8.0.6",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-          "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+          "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw=="
         }
       }
     },
     "@ipld/dag-cbor": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-5.0.5.tgz",
-      "integrity": "sha512-nSWGvqhwE9nHsrBx8YL4TiwhsitLhJ54Md5BMCUdK+s10QPxYsO7l/rRxU9bLV/L13WUTfLEll2K3Q2ijlZCWw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
+      "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
       "requires": {
-        "cborg": "^1.2.1",
-        "multiformats": "^8.0.3"
+        "cborg": "^1.6.0",
+        "multiformats": "^11.0.0"
       },
       "dependencies": {
         "multiformats": {
-          "version": "8.0.6",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-          "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
         }
       }
     },
@@ -6588,14 +6574,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
-    },
-    "@types/varint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
-      "integrity": "sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "acorn": {
       "version": "8.2.4",
@@ -8533,22 +8511,6 @@
         "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "@ipld/dag-cbor": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
-          "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
-          "requires": {
-            "cborg": "^1.6.0",
-            "multiformats": "^11.0.0"
-          },
-          "dependencies": {
-            "multiformats": {
-              "version": "11.0.0",
-              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
-              "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
-            }
-          }
-        },
         "it-pipe": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ipfs-get",
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@ipld/car": "^1.0.1",
-        "ipfs-unixfs-exporter": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb",
+        "ipfs-unixfs-exporter": "9.0.2",
         "isomorphic-unfetch": "^3.1.0",
         "it-pipe": "^1.1.0",
         "meow": "^10.0.0",
@@ -21,7 +22,7 @@
       },
       "devDependencies": {
         "ava": "^3.15.0",
-        "ipfs-unixfs-importer": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-importer?js-dag-pb",
+        "ipfs-unixfs-importer": "11.0.1",
         "standard": "^16.0.3"
       }
     },
@@ -179,22 +180,52 @@
       "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
     },
     "node_modules/@ipld/dag-pb": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-1.1.4.tgz",
-      "integrity": "sha512-jaB6mMjdagWEArr37L9LWtx52V5NwygM7wXH6CHyZeKjNOCr5eUbVUBIx0eaN1L25MaBSXhAH3CkOdFBmrqaTw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-3.0.2.tgz",
+      "integrity": "sha512-ge+llKU/CNc6rX5ZcUhCrPXJjKjN1DsolDOJ99zOsousGOhepoIgvT01iAP8s7QN9QFciOE+a1jHdccs+CyhBA==",
       "dependencies": {
-        "multiformats": "^8.0.3"
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@ipld/dag-pb/node_modules/multiformats": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@multiformats/base-x": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "node_modules/@multiformats/murmur3": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.1.tgz",
+      "integrity": "sha512-Tvugr3/M3N7azRCrqCSZfg2qAy3lTt547ImCcMKkCqZWNsABt8qF3pf0zmfYJIDGvcT3+xZWurznk3a1rrgoLw==",
+      "dependencies": {
+        "multiformats": "^11.0.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -234,7 +265,7 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
@@ -249,12 +280,12 @@
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -263,27 +294,27 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -311,11 +342,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
@@ -724,11 +750,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-    },
     "node_modules/blueimp-md5": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
@@ -921,9 +942,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.1.tgz",
-      "integrity": "sha512-neK2ovbsVY9KFKDUdwifRO0U6p0Y7mZ/08nPgPEV20mABkui+9Fiic63eiPg1TnWuD+Vzjmtp2xUWEdv+AtgFg==",
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
+      "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -2284,6 +2305,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2620,16 +2646,37 @@
       "dev": true
     },
     "node_modules/hamt-sharding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.0.tgz",
-      "integrity": "sha512-h8HKkMrqX6UC7I8hYRA1BT8pSC1TV1+V9HolGyWiNKRIztMQ980vWwjWZSLPFHtUKGMtOVBSVz5lIXuvlzwlWQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+      "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
       "dependencies": {
         "sparse-array": "^1.3.1",
-        "uint8arrays": "^2.1.2"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/hamt-sharding/node_modules/multiformats": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+      "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/hamt-sharding/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+      "dependencies": {
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/hard-rejection": {
@@ -2837,6 +2884,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/interface-blockstore": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-3.0.2.tgz",
+      "integrity": "sha512-lJXCyu3CwidOvNjkJARwCmoxl/HNX/mrfMxtyq5e/pVZA1SrlTj5lvb4LBYbfoynzewGUPcUU4DEUaXoLKliHQ==",
+      "dependencies": {
+        "interface-store": "^3.0.0",
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+      "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/interface-store": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.2.tgz",
+      "integrity": "sha512-HR/CIGHlX3H3if2uVQBlX3vMT/i8jICB8pnXIqibBfJ4Yf5yZn9o13o7UImkDHOq0P6wPhR6tVVenHs7y9iruA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -2852,77 +2930,150 @@
       }
     },
     "node_modules/ipfs-unixfs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
-      "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-8.0.0.tgz",
+      "integrity": "sha512-PAHtfyjiFs2PZBbeft5QRyXpVOvZ2zsGqID+zVRla7fjC1zRTqJkrGY9h6dF03ldGv/mSmFlNZh479qPC6aZKg==",
       "dependencies": {
         "err-code": "^3.0.1",
-        "protobufjs": "^6.10.2"
+        "protobufjs": "^7.0.0"
       },
       "engines": {
-        "node": ">=14.0.0",
+        "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-unixfs-exporter": {
-      "version": "5.0.3",
-      "resolved": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb",
-      "integrity": "sha512-2sEsgyoOQGOvscxVN/Fm7cdcsU6C2lMeB0c+Hj4o04U7pwL7opfYr6anf7ahE7D3gPj1INvjd0ne4SDYDwFGHQ==",
-      "license": "MIT",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-9.0.2.tgz",
+      "integrity": "sha512-CoktRT+MgS3H06/IXrmtJpuLQcux7ff30y0ndDRYnZLCvnqD2Fr3YicoY1sDb8JluIPZ70Pmwovb6Du4NfKk+w==",
       "dependencies": {
-        "@ipld/dag-cbor": "^5.0.0",
-        "@ipld/dag-pb": "^1.1.0",
+        "@ipld/dag-cbor": "^8.0.0",
+        "@ipld/dag-pb": "^3.0.0",
+        "@multiformats/murmur3": "^2.0.0",
         "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-last": "^1.0.5",
-        "multicodec": "^3.0.1",
-        "multiformats": "^8.0.3",
-        "multihashing-async": "^2.1.0"
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^3.0.0",
+        "ipfs-unixfs": "^8.0.0",
+        "it-last": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^10.0.0",
+        "p-queue": "^7.3.0",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
-        "node": ">=14.0.0",
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/@ipld/dag-cbor": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
+      "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
+      "dependencies": {
+        "cborg": "^1.6.0",
+        "multiformats": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+      "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-exporter/node_modules/it-pipe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+      "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+      "dependencies": {
+        "it-merge": "^2.0.0",
+        "it-pushable": "^3.1.0",
+        "it-stream-types": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-unixfs-exporter/node_modules/multiformats": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+      "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
-    "node_modules/ipfs-unixfs-importer": {
-      "version": "7.0.3",
-      "resolved": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-importer?js-dag-pb",
-      "integrity": "sha512-HP45mqPsDYGgtveYlreWO2FHlesuLLQUFr7Or5LCDqk53Pe2w9i0opQSVHKh1jZvtHhgO+kZvtRKzEoBbNnWZQ==",
-      "dev": true,
-      "license": "MIT",
+    "node_modules/ipfs-unixfs-exporter/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
       "dependencies": {
-        "@ipld/dag-pb": "^1.1.0",
-        "bl": "^5.0.0",
-        "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-all": "^1.0.5",
-        "it-batch": "^1.0.8",
-        "it-first": "^1.0.6",
-        "it-parallel-batch": "^1.0.9",
-        "merge-options": "^3.0.4",
-        "multicodec": "^3.0.1",
-        "multiformats": "^8.0.3",
-        "multihashing-async": "^2.1.0",
-        "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.2"
+        "multiformats": "^10.0.0"
       },
       "engines": {
-        "node": ">=14.0.0",
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-importer": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-11.0.1.tgz",
+      "integrity": "sha512-e7Ca5zj8MMcQAqQR1YQrEicgZEiUf0xoBLMmu/6g/PtZ0U1oZBFsaIHcbDIjjjrEXxxhK6IcAvqSfqqUBnGfBg==",
+      "dev": true,
+      "dependencies": {
+        "@ipld/dag-pb": "^3.0.0",
+        "@multiformats/murmur3": "^2.0.0",
+        "err-code": "^3.0.1",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^3.0.0",
+        "ipfs-unixfs": "^8.0.0",
+        "it-all": "^2.0.0",
+        "it-batch": "^2.0.0",
+        "it-first": "^2.0.0",
+        "it-parallel-batch": "^2.0.0",
+        "merge-options": "^3.0.4",
+        "multiformats": "^10.0.0",
+        "rabin-wasm": "^0.1.4",
+        "uint8arraylist": "^2.3.3",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-unixfs-importer/node_modules/multiformats": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-      "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg==",
-      "dev": true
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+      "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-importer/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/irregular-plurals": {
       "version": "3.3.0",
@@ -3267,35 +3418,99 @@
       }
     },
     "node_modules/it-all": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.5.tgz",
-      "integrity": "sha512-ygD4kA4vp8fi+Y+NBgEKt6W06xSbv6Ub/0V8d1r3uCyJ9Izwa1UspkIOlqY9fOee0Z1w3WRo1+VWyAU4DgtufA==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
+      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-batch": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.8.tgz",
-      "integrity": "sha512-RfEa1rxOPnicXvaXJ1qNThxPrq8/Lc+KwSVWHFEEOp2CrjpjhR5WfmBJozhkbzZ/r/Gl0HjzVVrt0NpG8qczDQ==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-2.0.0.tgz",
+      "integrity": "sha512-kh30J83cNGCXuH48+meNLSCjkhRzvZyySgiHJ+Vz0ch/YyQ/XgYSCQhbx2a2VbxhvDdYZBoKiI3x7h14ReYFcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-first": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.6.tgz",
-      "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
+      "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-last": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.5.tgz",
-      "integrity": "sha512-PV/2S4zg5g6dkVuKfgrQfN2rUN4wdTI1FzyAvU+i8RV96syut40pa2s9Dut5X7SkjwA3P0tOhLABLdnOJ0Y/4Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.0.tgz",
+      "integrity": "sha512-u0GHZ01tWYtPvDkOaqZSLLWjFv3IJw9cPL9mbEV7wnE8DOsbVoXIuKpnz3U6pySl5RzPVjTzSHOc961ZYttBxg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
+      "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-merge": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.0.tgz",
+      "integrity": "sha512-mH4bo/ZrMoU+Wlu7ZuYPNNh9oWZ/GvYbeXZ0zll97+Rp6H4jFu98iu6v9qqXDz//RUjdO9zGh8awzMfOElsjpA==",
+      "dependencies": {
+        "it-pushable": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-parallel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.0.tgz",
+      "integrity": "sha512-/y70cY7VoZ7natLbWrPxoRaKWMD67RvtWx21cyLJr6kkuHrUWOrHNr8CPMBqzDRh73aig/uUT82hzTTmTTkDUg==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/it-parallel-batch": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.9.tgz",
-      "integrity": "sha512-lfCxXsHoEtgyWj5HLrEQXlZF0p3c0hfYeVJAbxQIHIzHLq4lkYplUIe3UGxYl4n1Sjpcs6YL/87352399aVeIA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-2.0.0.tgz",
+      "integrity": "sha512-RWP3h1y1OW3kzP633640mqgcfA9rlGGv4XV7EIsdU8VzAv+hRbpibqFk8sUyN/tNjrcFcYNkGBTE0/0FYf65IQ==",
       "dev": true,
       "dependencies": {
-        "it-batch": "^1.0.8"
+        "it-batch": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-parallel/node_modules/p-defer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/it-pipe": {
@@ -3303,10 +3518,23 @@
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
       "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    "node_modules/it-pushable": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
+      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/it-stream-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
+      "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
     },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
@@ -3497,9 +3725,9 @@
       }
     },
     "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3835,23 +4063,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
       "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-    },
-    "node_modules/multihashing-async": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.2.tgz",
-      "integrity": "sha512-FTPNnWWxwIK5dXXmTFhySSF8Fkdqf7vzqpV09+RWsmfUhrsL/b3Arg3+bRrBnXTtjxm3JRGI3wSAtQHL0QCxhQ==",
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "err-code": "^3.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^4.0.1",
-        "murmurhash3js-revisited": "^3.0.0",
-        "uint8arrays": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -4195,6 +4406,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
+      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.7",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -4476,9 +4713,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -4491,13 +4728,11 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/pump": {
@@ -5700,6 +5935,42 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/uint8arraylist": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+      "dev": true,
+      "dependencies": {
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+      "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+      "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/uint8arrays": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.5.tgz",
@@ -6167,17 +6438,17 @@
       }
     },
     "@ipld/dag-pb": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-1.1.4.tgz",
-      "integrity": "sha512-jaB6mMjdagWEArr37L9LWtx52V5NwygM7wXH6CHyZeKjNOCr5eUbVUBIx0eaN1L25MaBSXhAH3CkOdFBmrqaTw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-3.0.2.tgz",
+      "integrity": "sha512-ge+llKU/CNc6rX5ZcUhCrPXJjKjN1DsolDOJ99zOsousGOhepoIgvT01iAP8s7QN9QFciOE+a1jHdccs+CyhBA==",
       "requires": {
-        "multiformats": "^8.0.3"
+        "multiformats": "^11.0.0"
       },
       "dependencies": {
         "multiformats": {
-          "version": "8.0.6",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-          "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
         }
       }
     },
@@ -6185,6 +6456,22 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
+    "@multiformats/murmur3": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.1.tgz",
+      "integrity": "sha512-Tvugr3/M3N7azRCrqCSZfg2qAy3lTt547ImCcMKkCqZWNsABt8qF3pf0zmfYJIDGvcT3+xZWurznk3a1rrgoLw==",
+      "requires": {
+        "multiformats": "^11.0.0",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+          "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+        }
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -6215,7 +6502,7 @@
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
@@ -6230,12 +6517,12 @@
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -6244,27 +6531,27 @@
     "@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
@@ -6286,11 +6573,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
-    },
-    "@types/long": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/minimist": {
       "version": "1.2.1",
@@ -6600,11 +6882,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "blakejs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
-    },
     "blueimp-md5": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
@@ -6739,9 +7016,9 @@
       }
     },
     "cborg": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.1.tgz",
-      "integrity": "sha512-neK2ovbsVY9KFKDUdwifRO0U6p0Y7mZ/08nPgPEV20mABkui+9Fiic63eiPg1TnWuD+Vzjmtp2xUWEdv+AtgFg=="
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
+      "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ=="
     },
     "chalk": {
       "version": "4.1.1",
@@ -7768,6 +8045,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8029,12 +8311,27 @@
       "dev": true
     },
     "hamt-sharding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.0.tgz",
-      "integrity": "sha512-h8HKkMrqX6UC7I8hYRA1BT8pSC1TV1+V9HolGyWiNKRIztMQ980vWwjWZSLPFHtUKGMtOVBSVz5lIXuvlzwlWQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+      "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
       "requires": {
         "sparse-array": "^1.3.1",
-        "uint8arrays": "^2.1.2"
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+          "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
+        }
       }
     },
     "hard-rejection": {
@@ -8173,6 +8470,27 @@
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
       "dev": true
     },
+    "interface-blockstore": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-3.0.2.tgz",
+      "integrity": "sha512-lJXCyu3CwidOvNjkJARwCmoxl/HNX/mrfMxtyq5e/pVZA1SrlTj5lvb4LBYbfoynzewGUPcUU4DEUaXoLKliHQ==",
+      "requires": {
+        "interface-store": "^3.0.0",
+        "multiformats": "^10.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+          "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw=="
+        }
+      }
+    },
+    "interface-store": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-3.0.2.tgz",
+      "integrity": "sha512-HR/CIGHlX3H3if2uVQBlX3vMT/i8jICB8pnXIqibBfJ4Yf5yZn9o13o7UImkDHOq0P6wPhR6tVVenHs7y9iruA=="
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -8185,63 +8503,114 @@
       }
     },
     "ipfs-unixfs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
-      "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-8.0.0.tgz",
+      "integrity": "sha512-PAHtfyjiFs2PZBbeft5QRyXpVOvZ2zsGqID+zVRla7fjC1zRTqJkrGY9h6dF03ldGv/mSmFlNZh479qPC6aZKg==",
       "requires": {
         "err-code": "^3.0.1",
-        "protobufjs": "^6.10.2"
+        "protobufjs": "^7.0.0"
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb",
-      "integrity": "sha512-2sEsgyoOQGOvscxVN/Fm7cdcsU6C2lMeB0c+Hj4o04U7pwL7opfYr6anf7ahE7D3gPj1INvjd0ne4SDYDwFGHQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-9.0.2.tgz",
+      "integrity": "sha512-CoktRT+MgS3H06/IXrmtJpuLQcux7ff30y0ndDRYnZLCvnqD2Fr3YicoY1sDb8JluIPZ70Pmwovb6Du4NfKk+w==",
       "requires": {
-        "@ipld/dag-cbor": "^5.0.0",
-        "@ipld/dag-pb": "^1.1.0",
+        "@ipld/dag-cbor": "^8.0.0",
+        "@ipld/dag-pb": "^3.0.0",
+        "@multiformats/murmur3": "^2.0.0",
         "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-last": "^1.0.5",
-        "multicodec": "^3.0.1",
-        "multiformats": "^8.0.3",
-        "multihashing-async": "^2.1.0"
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^3.0.0",
+        "ipfs-unixfs": "^8.0.0",
+        "it-last": "^2.0.0",
+        "it-map": "^2.0.0",
+        "it-parallel": "^3.0.0",
+        "it-pipe": "^2.0.4",
+        "it-pushable": "^3.1.0",
+        "multiformats": "^10.0.0",
+        "p-queue": "^7.3.0",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
+        "@ipld/dag-cbor": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-8.0.1.tgz",
+          "integrity": "sha512-mHRuzgGXNk0Y5W7nNQdN37qJiig1Kdgf92icBVFRUNtBc9Ezl5DIdWfiGWBucHBrhqPBncxoH3As9cHPIRozxA==",
+          "requires": {
+            "cborg": "^1.6.0",
+            "multiformats": "^11.0.0"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "11.0.0",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.0.tgz",
+              "integrity": "sha512-vqF8bmMtbxw9Zn3eTpk0OZQdBVmAT/+bTGwXb3C2qCNkp45aJMmkCDds3lrtObECWPf+KFjFtTOHkvCaT/c/xQ=="
+            }
+          }
+        },
+        "it-pipe": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
+          "integrity": "sha512-y85nW1N6zoiTnkidr2EAyC+ZVzc7Mwt2p+xt2a2ooG1ThFakSpNw1Kxm+7F13Aivru96brJhjQVRQNU+w0yozw==",
+          "requires": {
+            "it-merge": "^2.0.0",
+            "it-pushable": "^3.1.0",
+            "it-stream-types": "^1.0.3"
+          }
+        },
         "multiformats": {
-          "version": "8.0.6",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-          "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg=="
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+          "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw=="
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
         }
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-importer?js-dag-pb",
-      "integrity": "sha512-HP45mqPsDYGgtveYlreWO2FHlesuLLQUFr7Or5LCDqk53Pe2w9i0opQSVHKh1jZvtHhgO+kZvtRKzEoBbNnWZQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-11.0.1.tgz",
+      "integrity": "sha512-e7Ca5zj8MMcQAqQR1YQrEicgZEiUf0xoBLMmu/6g/PtZ0U1oZBFsaIHcbDIjjjrEXxxhK6IcAvqSfqqUBnGfBg==",
       "dev": true,
       "requires": {
-        "@ipld/dag-pb": "^1.1.0",
-        "bl": "^5.0.0",
+        "@ipld/dag-pb": "^3.0.0",
+        "@multiformats/murmur3": "^2.0.0",
         "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "it-all": "^1.0.5",
-        "it-batch": "^1.0.8",
-        "it-first": "^1.0.6",
-        "it-parallel-batch": "^1.0.9",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^3.0.0",
+        "ipfs-unixfs": "^8.0.0",
+        "it-all": "^2.0.0",
+        "it-batch": "^2.0.0",
+        "it-first": "^2.0.0",
+        "it-parallel-batch": "^2.0.0",
         "merge-options": "^3.0.4",
-        "multicodec": "^3.0.1",
-        "multiformats": "^8.0.3",
-        "multihashing-async": "^2.1.0",
+        "multiformats": "^10.0.0",
         "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.2"
+        "uint8arraylist": "^2.3.3",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
         "multiformats": {
-          "version": "8.0.6",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-8.0.6.tgz",
-          "integrity": "sha512-pG+WjFje4KUE54CrHfqhzmoxgf/9om7CBaxVzf264cW9JwsF8yXfc/RJIaqxrrD4RqUnvgkWhJ1aqMNPApI/Qg==",
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+          "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
           "dev": true
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
         }
       }
     },
@@ -8477,35 +8846,63 @@
       }
     },
     "it-all": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.5.tgz",
-      "integrity": "sha512-ygD4kA4vp8fi+Y+NBgEKt6W06xSbv6Ub/0V8d1r3uCyJ9Izwa1UspkIOlqY9fOee0Z1w3WRo1+VWyAU4DgtufA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-2.0.0.tgz",
+      "integrity": "sha512-I/yi9ogTY59lFxtfsDSlI9w9QZtC/5KJt6g7CPPBJJh2xql2ZS7Ghcp9hoqDDbc4QfwQvtx8Loy0zlKQ8H5gFg==",
       "dev": true
     },
     "it-batch": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.8.tgz",
-      "integrity": "sha512-RfEa1rxOPnicXvaXJ1qNThxPrq8/Lc+KwSVWHFEEOp2CrjpjhR5WfmBJozhkbzZ/r/Gl0HjzVVrt0NpG8qczDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-2.0.0.tgz",
+      "integrity": "sha512-kh30J83cNGCXuH48+meNLSCjkhRzvZyySgiHJ+Vz0ch/YyQ/XgYSCQhbx2a2VbxhvDdYZBoKiI3x7h14ReYFcg==",
       "dev": true
     },
     "it-first": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.6.tgz",
-      "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-2.0.0.tgz",
+      "integrity": "sha512-fzZGzVf01exFyIZXNjkpSMFr1eW2+J1K0v018tYY26Dd4f/O3pWlBTdrOBfSQRZwtI8Pst6c7eKhYczWvFs6tA==",
       "dev": true
     },
     "it-last": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.5.tgz",
-      "integrity": "sha512-PV/2S4zg5g6dkVuKfgrQfN2rUN4wdTI1FzyAvU+i8RV96syut40pa2s9Dut5X7SkjwA3P0tOhLABLdnOJ0Y/4Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-2.0.0.tgz",
+      "integrity": "sha512-u0GHZ01tWYtPvDkOaqZSLLWjFv3IJw9cPL9mbEV7wnE8DOsbVoXIuKpnz3U6pySl5RzPVjTzSHOc961ZYttBxg=="
+    },
+    "it-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-map/-/it-map-2.0.0.tgz",
+      "integrity": "sha512-mLgtk/NZaN7NZ06iLrMXCA6jjhtZO0vZT5Ocsp31H+nsGI18RSPVmUbFyA1sWx7q+g92J22Sixya7T2QSSAwfA=="
+    },
+    "it-merge": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-2.0.0.tgz",
+      "integrity": "sha512-mH4bo/ZrMoU+Wlu7ZuYPNNh9oWZ/GvYbeXZ0zll97+Rp6H4jFu98iu6v9qqXDz//RUjdO9zGh8awzMfOElsjpA==",
+      "requires": {
+        "it-pushable": "^3.1.0"
+      }
+    },
+    "it-parallel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/it-parallel/-/it-parallel-3.0.0.tgz",
+      "integrity": "sha512-/y70cY7VoZ7natLbWrPxoRaKWMD67RvtWx21cyLJr6kkuHrUWOrHNr8CPMBqzDRh73aig/uUT82hzTTmTTkDUg==",
+      "requires": {
+        "p-defer": "^4.0.0"
+      },
+      "dependencies": {
+        "p-defer": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
+          "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ=="
+        }
+      }
     },
     "it-parallel-batch": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.9.tgz",
-      "integrity": "sha512-lfCxXsHoEtgyWj5HLrEQXlZF0p3c0hfYeVJAbxQIHIzHLq4lkYplUIe3UGxYl4n1Sjpcs6YL/87352399aVeIA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-2.0.0.tgz",
+      "integrity": "sha512-RWP3h1y1OW3kzP633640mqgcfA9rlGGv4XV7EIsdU8VzAv+hRbpibqFk8sUyN/tNjrcFcYNkGBTE0/0FYf65IQ==",
       "dev": true,
       "requires": {
-        "it-batch": "^1.0.8"
+        "it-batch": "^2.0.0"
       }
     },
     "it-pipe": {
@@ -8513,10 +8910,15 @@
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
       "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    "it-pushable": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
+      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
+    },
+    "it-stream-types": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-1.0.5.tgz",
+      "integrity": "sha512-I88Ka1nHgfX62e5mi5LLL+oueqz7Ltg0bUdtsUKDe9SoUqbQPf2Mp5kxDTe9pNhHQGs4pvYPAINwuZ1HAt42TA=="
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -8673,9 +9075,9 @@
       }
     },
     "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
+      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -8930,19 +9332,6 @@
         }
       }
     },
-    "multihashing-async": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.2.tgz",
-      "integrity": "sha512-FTPNnWWxwIK5dXXmTFhySSF8Fkdqf7vzqpV09+RWsmfUhrsL/b3Arg3+bRrBnXTtjxm3JRGI3wSAtQHL0QCxhQ==",
-      "requires": {
-        "blakejs": "^1.1.0",
-        "err-code": "^3.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^4.0.1",
-        "murmurhash3js-revisited": "^3.0.0",
-        "uint8arrays": "^2.1.3"
-      }
-    },
     "murmurhash3js-revisited": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
@@ -9182,6 +9571,22 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-queue": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
+      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "requires": {
+        "eventemitter3": "^4.0.7",
+        "p-timeout": "^5.0.2"
+      },
+      "dependencies": {
+        "p-timeout": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+        }
+      }
+    },
     "p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -9386,9 +9791,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-      "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
+      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9400,9 +9805,8 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       }
     },
     "pump": {
@@ -10258,6 +10662,32 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "uint8arraylist": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
+      "integrity": "sha512-oEVZr4/GrH87K0kjNce6z8pSCzLEPqHNLNR5sj8cJOySrTP8Vb/pMIbZKLJGhQKxm1TiZ31atNrpn820Pyqpow==",
+      "dev": true,
+      "requires": {
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "10.0.3",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
+          "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw==",
+          "dev": true
+        },
+        "uint8arrays": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-4.0.2.tgz",
+          "integrity": "sha512-8CWXXZdOvVrIL4SeY/Gnp+idxxiGK4XFkP4FY26Sx/fpTz/b6vv4BVWELMDzQweSyyhdcuAcU14H6izzB6k1Cw==",
+          "dev": true,
+          "requires": {
+            "multiformats": "^10.0.0"
+          }
+        }
       }
     },
     "uint8arrays": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@ipld/car": "^1.0.1",
-    "ipfs-unixfs-exporter": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-exporter?js-dag-pb",
+    "ipfs-unixfs-exporter": "9.0.2",
     "isomorphic-unfetch": "^3.1.0",
     "it-pipe": "^1.1.0",
     "meow": "^10.0.0",
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "ava": "^3.15.0",
-    "ipfs-unixfs-importer": "https://gitpkg.now.sh/ipfs/js-ipfs-unixfs/packages/ipfs-unixfs-importer?js-dag-pb",
+    "ipfs-unixfs-importer": "11.0.1",
     "standard": "^16.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "olizilla",
   "license": "MIT",
   "dependencies": {
-    "@ipld/car": "^1.0.1",
+    "@ipld/car": "^5.0.1",
     "ipfs-unixfs-exporter": "9.0.2",
     "isomorphic-unfetch": "^3.1.0",
     "it-pipe": "^1.1.0",

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ import { createReadStream } from 'fs'
 import fs from 'fs/promises'
 import test from 'ava'
 import { extractCar } from './index.js'
-import CarIndexedReader from '@ipld/car/indexed-reader'
+import { CarIndexedReader } from '@ipld/car/indexed-reader'
 import { importer } from 'ipfs-unixfs-importer'
 
 test('extract single raw unix-fs block', async t => {


### PR DESCRIPTION
This PR introduces several changes:
- fixes a bug arising from the wrong return value in `verifyingBlockService` https://github.com/olizilla/ipfs-get/blob/6a62dfaff76e04961958e7577bdbdfe5d27d00c6/index.js#L49
- Upgrades some of the IPLD/IPFS dependencies 
- Uses the CAR response in gateways based on [the spec](https://github.com/ipfs/specs/blob/main/http-gateways/TRUSTLESS_GATEWAY.md#accept-request-header) 

 
Fixes #12
Fixes #6 